### PR TITLE
background ssh task runner and handler functionality

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,9 @@ scheduler:
 
 sdvn:
   ip: "10.9.0.69"
+  background: > 
+      tail -n 0 -f /var/log/magrtrsrv.log > sxm_router.txt & 
+      tail -n 0 -f /var/log/magclientsrv.log > sxm_client.txt
   commands: 
     - "python3 sdvn_script.py"
     - "echo Done with sdvn"

--- a/internal/config.go
+++ b/internal/config.go
@@ -14,8 +14,9 @@ type HostSSHConfig struct {
 }
 
 type HostConfig struct {
-	IP       string   `mapstructure:"ip"`
-	Commands []string `mapstructure:"commands"`
+	IP            string   `mapstructure:"ip"`
+	Commands      []string `mapstructure:"commands"`
+	BackgroundCmd string   `mapstructure:"background"`
 }
 
 type LocalConfig struct {


### PR DESCRIPTION
ability to run a remote ssh command that can be persistant and then closed later. useful for tailiing log files while other tasks are executing.  updated the config file structure for a background command